### PR TITLE
Refresh the pacman keyring before installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,11 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.license=MIT \
       org.label-schema.schema-version="1.0"
 
+# Refresh the keyring
+RUN pacman-key --init \
+ && pacman-key --populate archlinux \
+ && pacman-key --refresh-keys
+
 # Optimise the mirror list
 RUN pacman --noconfirm -Syyu \
  && pacman-db-upgrade \


### PR DESCRIPTION
Docker builds are currently failing with
```error: krb5: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust
:: File /var/cache/pacman/pkg/krb5-1.13.7-1-x86_64.pkg.tar.xz is corrupted (invalid or corrupted package (PGP signature)).

Do you want to delete it? [Y/n] error: libpsl: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust
```

This change ensures the keyring is refreshed first. which solves the build error